### PR TITLE
Support for fetch tweet by Id

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ Settings are expected as below:
 
     $client = new Client($settings);
 
+### To fetch a tweet by Id
+Example:
+
+    $result = $client->tweet()->performRequest('GET', array( 'id' => $id));
+
+
 ### To search specific tweets
 Example:
 

--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -93,6 +93,13 @@ abstract class AbstractController
                 $client = new Client(['base_uri' => self::API_BASE_URI]);
 
                 $headers['Authorization'] = 'Bearer ' . $this->bearer_token;
+
+                // if GET method with id set, fetch tweet with id
+                if( is_array( $postData ) && isset( $postData['id'] ) && is_numeric( $postData['id']))  {
+                    $this->endpoint .= '/'.$postData['id'];
+                    // unset to avoid clash later.
+                    unset( $postData['id'] );
+                }
             } else {
                 // Inject Oauth handler
                 $stack = HandlerStack::create();
@@ -113,7 +120,8 @@ abstract class AbstractController
 
             $response  = $client->request($method, $this->constructEndpoint(), [
                 'headers' => $headers,
-                'json'    => $postData ?: null
+                        // this is always array from function spec,use count to see if data set. Otherwise twitter error on empty data.
+                'json'    => count($postData) ? $postData: null,
             ]);
 
             $body = json_decode($response->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR);

--- a/test/TwitterTest.php
+++ b/test/TwitterTest.php
@@ -99,6 +99,23 @@ class TwitterTest extends TestCase
     }
 
     /**
+     * Case 5: Fetch Tweet by Id
+     * @throws \JsonException|\Exception
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function testFetchTweet(): void
+    {
+        $return =
+            $this->twitterClient->tweet()->performRequest(
+            'GET',
+             [
+                'id' => '1455953449422516226'
+             ]
+        );
+        $this->assertIsObject($return);
+    }
+
+    /**
      * Return a list of tweets with users details
      * @param array<string> $keywords
      * @param array<string> $usernames


### PR DESCRIPTION
Sample and Test included.

Use GET method and param array with id=>123456

Also, small change in postData handling to overcome Twitter error with empty postData.