### PR TITLE
Bump guzzlehttp/oauth-subscriber to 0.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-json": "*",
     "php": ">=7.4",
     "guzzlehttp/guzzle": "^7.5.0",
-    "guzzlehttp/oauth-subscriber": "^0.6.0"
+    "guzzlehttp/oauth-subscriber": "^0.8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.3",


### PR DESCRIPTION
- Bump `guzzlehttp/oauth-subscriber` to 0.8.* (fix #61) 
- Fix PHPStan errors, align error handling in `AbstractController` and `Media`