### PR TITLE
added previous exception so data is not lost

### DIFF
--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -155,7 +155,7 @@ abstract class AbstractController
             $payload = json_decode($e->getResponse()->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR);
             throw new \RuntimeException($payload->detail ?? $e->getMessage(), $payload->status ?? $e->getCode());
         } catch (RequestException $e) {
-            throw new \RuntimeException($e->getMessage(), $e->getCode());
+            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
This adds the original exception to the throw.
This should allow 
`$e->getPrevious()->getResponse()->getHeaders()`

Fixes #64 